### PR TITLE
Fix signal channels dtype

### DIFF
--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -564,7 +564,8 @@ class AxonaRawIO(BaseRawIO):
 
         elec_per_tetrode = 4
         letters = ['a', 'b', 'c', 'd']
-        dtype = self.file_parameters['bin']['data_type']
+        # TODO make proper fix for dtype
+        dtype = 'int16'  # self.file_parameters['bin']['data_type']
         units = 'uV'
         gain_list = self._get_channel_gain()
         offset = 0  # What is the offset?

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -389,14 +389,14 @@ class AxonaRawIO(BaseRawIO):
         if t_start is None and t_stop is None:
             waveforms = waveforms.reshape(nb_spikes, 4, nb_samples_per_waveform)
             return waveforms
-        
+
         if t_start is None:
             t_start = self._segment_t_start(block_index, seg_index)
         if t_stop is None:
             t_stop = self._segment_t_stop(block_index, seg_index)
 
         mask = self._get_temporal_mask(t_start, t_stop, tetrode_id)
-        
+
         # unwrap mask to match waveform dimension
         mask = np.repeat(mask, 4)
         mask = mask[:len(waveforms)]
@@ -435,7 +435,7 @@ class AxonaRawIO(BaseRawIO):
     # This is largely based on code by Geoff Barrett from the Hussaini lab:
     # https://github.com/GeoffBarrett/BinConverter
     # Adapted or modified by Steffen Buergers, Julia Sprenger
-    
+
     def _get_temporal_mask(self, t_start, t_stop, tetrode_id):
         # Convenience function for creating a temporal mask given
         # start time (t_start) and stop time (t_stop)
@@ -444,7 +444,7 @@ class AxonaRawIO(BaseRawIO):
         # spike times are repeated for each contact -> use only first contact
         raw_spikes = self._raw_spikes[tetrode_id]
         unit_spikes = raw_spikes['spiketimes'][::4]
-        
+
         # convert t_start and t_stop to sampling frequency
         # Note: this assumes no time offset!
         unit_params = self.file_parameters['unit']
@@ -452,7 +452,7 @@ class AxonaRawIO(BaseRawIO):
         lim1 = t_stop * self._to_hz(unit_params['timebase'])
 
         mask = (unit_spikes >= lim0) & (unit_spikes <= lim1)
-        
+
         return mask
 
     def get_header_parameters(self, file, file_type):
@@ -588,4 +588,4 @@ class AxonaRawIO(BaseRawIO):
         return np.array(sig_channels, dtype=_signal_channel_dtype)
 
     def _to_hz(self, param, dtype=int):
-        return dtype(param.replace(' hz',''))
+        return dtype(param.replace(' hz', ''))

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -107,7 +107,7 @@ class AxonaRawIO(BaseRawIO):
                           'bytes_data': 384,
                           'bytes_head': 32,
                           'bytes_tail': 16,
-                          'data_type': np.int16,
+                          'data_type': 'int16',
                           'header_size': 0,
                           # bin files don't contain a file header
                           'header_encoding': None},
@@ -564,8 +564,7 @@ class AxonaRawIO(BaseRawIO):
 
         elec_per_tetrode = 4
         letters = ['a', 'b', 'c', 'd']
-        # TODO make proper fix for dtype
-        dtype = 'int16'  # self.file_parameters['bin']['data_type']
+        dtype = self.file_parameters['bin']['data_type']
         units = 'uV'
         gain_list = self._get_channel_gain()
         offset = 0  # What is the offset?


### PR DESCRIPTION
I noticed that in `_get_signal_chan_header()` the dtype of the data is ultimately returned as a nonsensical string:

```
array([('1a', '0', 48000., "<class 'numpy.in", 'uV', 1.171875 , 0., '0'),
       ('1b', '1', 48000., "<class 'numpy.in", 'uV', 1.171875 , 0., '0'),
       ('1c', '2', 48000., "<class 'numpy.in", 'uV', 1.171875 , 0., '0'),
```

This is because in `_signal_channel_dtype` the fourth entry is `('dtype', 'U16')`, which deals with strings. In any case to reproduce:

```
import numpy as np
np.array([np.int16], dtype=('U16'))
```

This didn't cause a problem before, but I am trying to add axona to the new spikeinterface API now and there it does crash. Since we import `_signal_channel_dtype` from `neo.rawio.baserawio` , I reckon we should not change anything in it. Instead we could pass `'int16'` instead of `np.int16`, which is what I did for now. 

`test_axonarawio.py` passed locally for me.