### PR TITLE
Fix/allow missing bin file

### DIFF
--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -592,4 +592,4 @@ class AxonaRawIO(BaseRawIO):
         return np.array(sig_channels, dtype=_signal_channel_dtype)
 
     def _to_hz(self, param, dtype=int):
-        return dtype(param.replace(' hz',''))
+        return dtype(param.replace(' hz', ''))

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -270,7 +270,7 @@ class AxonaRawIO(BaseRawIO):
             return self.file_parameters['bin']['num_total_samples']
         else:
             sr = self.file_parameters['set']['sampling_rate']
-            return float(self.file_parameters['unit']['duration']) * sr
+            return int(self.file_parameters['unit']['duration'] * sr)
 
     def _get_signal_t_start(self, block_index, seg_index, stream_index):
         return 0.

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -294,26 +294,19 @@ class AxonaRawIO(BaseRawIO):
         sample 3: 32b (head) + 128*2 (all channels 1st and 2nd entry) + ...
         """
 
-        if self.bin_file is None:
-
-            # NOTE: Passing None or an empty array is not permitted in neo. Here,
-            # we create a fake continuous recording from the tetrode files, filling
-            # data in-between spikes with Gaussian noise. Ultimately we may want to
-            # move the axonaunitextractor.get_traces() code in here instead, going
-            # back and forth is a bit funny.
-            from spikeextractors.extractors.axonaunitrecordingextractor import AxonaUnitRecordingExtractor
-            ue = AxonaUnitRecordingExtractor(filename=self.set_file)
-            return ue.get_traces(return_scaled=False).transpose()
-
         bin_dict = self.file_parameters['bin']
 
         # Set default values
         if i_start is None:
             i_start = 0
         if i_stop is None:
-            i_stop = bin_dict['num_total_samples']
+            i_stop = self.get_signal_size(block_index=block_index, seg_index=seg_index)
         if channel_indexes is None:
-            channel_indexes = [i for i in range(bin_dict['num_channels'])]
+            channel_indexes = [i for i in range(self.header['signal_channels'].shape[0])]
+
+        if self.bin_file is None:
+            return self._get_mock_analogsignal_chunk(channel_ids=channel_indexes,
+                                                     start_frame=i_start, end_frame=i_stop)
 
         num_samples = (i_stop - i_start)
 
@@ -324,7 +317,7 @@ class AxonaRawIO(BaseRawIO):
 
         raw_samples = np.arange(num_packets_oi + 1, dtype=np.uint32)
         sample1 = raw_samples * (bin_dict['bytes_packet'] // 2) + \
-                  bin_dict['bytes_head'] // 2 + offset
+            bin_dict['bytes_head'] // 2 + offset
         sample2 = sample1 + 64
         sample3 = sample2 + 64
 
@@ -345,6 +338,98 @@ class AxonaRawIO(BaseRawIO):
             raw_signals[:, i] = self._raw_signals[sig_ids + chan_offset]
 
         return raw_signals
+
+    def _get_mock_analogsignal_chunk(self, channel_ids, start_frame, end_frame,
+                                     noise_std=0, return_scaled=False):
+        # Create mock continuous recording from tetrode file (.X) data
+        # by filling Gaussian noise into gaps between waveforms.
+
+        timebase_sr = int(self.file_parameters['unit']['timebase'].split(' ')[0])
+        samples_pre = int(self.file_parameters['set']['file_header']['pretrigSamps'])
+        samples_post = int(self.file_parameters['set']['file_header']['spikeLockout'])
+        sampling_rate = int(self.file_parameters['set']['sampling_rate'])
+
+        tcmap = self._get_tetrode_channel_table(channel_ids)
+
+        traces = noise_std * np.random.randn(len(channel_ids), end_frame - start_frame)
+        if return_scaled:
+            traces = traces.astype(np.float32)
+        else:
+            traces = traces.astype(np.int8)
+
+        # Loop through tetrodes and include requested channels in traces
+        itrc = 0
+        for tetrode_id in np.unique(tcmap[:, 0]):
+
+            channels_oi = tcmap[tcmap[:, 0] == tetrode_id, 2]
+
+            waveforms = self._get_spike_raw_waveforms(
+                block_index=0, seg_index=0,
+                unit_index=tetrode_id - 1,  # Tetrodes IDs are 1-indexed
+                t_start=start_frame / sampling_rate,
+                t_stop=end_frame / sampling_rate
+            )
+            waveforms = waveforms[:, channels_oi, :]
+            nch = len(channels_oi)
+
+            spike_train = self._get_spike_timestamps(
+                block_index=0, seg_index=0,
+                unit_index=tetrode_id - 1,
+                t_start=start_frame / sampling_rate,
+                t_stop=end_frame / sampling_rate
+            )
+
+            # Fill waveforms into traces timestamp by timestamp
+            for t, wf in zip(spike_train, waveforms):
+
+                t = int(t // (timebase_sr / sampling_rate))  # timestamps are sampled at higher frequency
+                t = t - start_frame
+                if (t - samples_pre < 0) and (t + samples_post > traces.shape[1]):
+                    traces[itrc:itrc + nch, :] = wf[:, samples_pre - t:traces.shape[1] - (t - samples_pre)]
+                elif t - samples_pre < 0:
+                    traces[itrc:itrc + nch, :t + samples_post] = wf[:, samples_pre - t:]
+                elif t + samples_post > traces.shape[1]:
+                    traces[itrc:itrc + nch, t - samples_pre:] = wf[:, :traces.shape[1] - (t - samples_pre)]
+                else:
+                    traces[itrc:itrc + nch, t - samples_pre:t + samples_post] = wf
+
+            itrc += nch
+
+        return traces.transpose()
+
+    def _get_tetrode_channel_table(self, channel_ids):
+        '''Create auxiliary np.array with the following columns:
+        Tetrode ID, Channel ID, Channel ID within tetrode
+        This is useful in `get_traces()`
+
+        Parameters
+        ----------
+        channel_ids : list
+            List of channel ids to include in table
+
+        Returns
+        -------
+        np.array
+            Rows = channels,
+            columns = TetrodeID, ChannelID, ChannelID within Tetrode
+        '''
+        active_tetrodes = self.get_active_tetrode()
+
+        tcmap = np.zeros((len(active_tetrodes) * 4, 3), dtype=int)
+        row_id = 0
+        for tetrode_id in [int(s[0].split(' ')[1]) for s in self.header['spike_channels']]:
+
+            all_channel_ids = self._get_channel_from_tetrode(tetrode_id)
+
+            for i in range(4):
+                tcmap[row_id, 0] = int(tetrode_id)
+                tcmap[row_id, 1] = int(all_channel_ids[i])
+                tcmap[row_id, 2] = int(i)
+                row_id += 1
+
+        del_idx = [False if i in channel_ids else True for i in tcmap[:, 1]]
+
+        return np.delete(tcmap, del_idx, axis=0)
 
     def _spike_count(self, block_index, seg_index, unit_index):
         tetrode_id = unit_index

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -382,14 +382,16 @@ class AxonaRawIO(BaseRawIO):
             # Fill waveforms into traces timestamp by timestamp
             for t, wf in zip(spike_train, waveforms):
 
-                t = int(t // (timebase_sr / sampling_rate))  # timestamps are sampled at higher frequency
+                t = int(t // (timebase_sr / sampling_rate))  # timestamps are at higher frequency
                 t = t - start_frame
                 if (t - samples_pre < 0) and (t + samples_post > traces.shape[1]):
-                    traces[itrc:itrc + nch, :] = wf[:, samples_pre - t:traces.shape[1] - (t - samples_pre)]
+                    traces[itrc:itrc + nch, :] = \
+                        wf[:, samples_pre - t:traces.shape[1] - (t - samples_pre)]
                 elif t - samples_pre < 0:
                     traces[itrc:itrc + nch, :t + samples_post] = wf[:, samples_pre - t:]
                 elif t + samples_post > traces.shape[1]:
-                    traces[itrc:itrc + nch, t - samples_pre:] = wf[:, :traces.shape[1] - (t - samples_pre)]
+                    traces[itrc:itrc + nch, t - samples_pre:] = \
+                        wf[:, :traces.shape[1] - (t - samples_pre)]
                 else:
                     traces[itrc:itrc + nch, t - samples_pre:t + samples_post] = wf
 

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -260,7 +260,7 @@ class AxonaRawIO(BaseRawIO):
                 raise ValueError('Can not determine common tetrode recording'
                                  'duration.')
 
-            tetrode_duration = int(self.file_parameters['unit']['duration'])
+            tetrode_duration = float(self.file_parameters['unit']['duration'])
             t_stop = max(t_stop, tetrode_duration)
 
         return t_stop
@@ -270,7 +270,7 @@ class AxonaRawIO(BaseRawIO):
             return self.file_parameters['bin']['num_total_samples']
         else:
             sr = self.file_parameters['set']['sampling_rate']
-            return int(self.file_parameters['unit']['duration']) * sr
+            return float(self.file_parameters['unit']['duration']) * sr
 
     def _get_signal_t_start(self, block_index, seg_index, stream_index):
         return 0.

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -266,7 +266,11 @@ class AxonaRawIO(BaseRawIO):
         return t_stop
 
     def _get_signal_size(self, block_index, seg_index, channel_indexes=None):
-        return self.file_parameters['bin']['num_total_samples']
+        if 'num_total_packets' in self.file_parameters['bin']:
+            return self.file_parameters['bin']['num_total_samples']
+        else:
+            sr = self.file_parameters['set']['sampling_rate']
+            return int(self.file_parameters['unit']['duration']) * sr
 
     def _get_signal_t_start(self, block_index, seg_index, stream_index):
         return 0.
@@ -387,14 +391,14 @@ class AxonaRawIO(BaseRawIO):
         if t_start is None and t_stop is None:
             waveforms = waveforms.reshape(nb_spikes, 4, nb_samples_per_waveform)
             return waveforms
-        
+
         if t_start is None:
             t_start = self._segment_t_start(block_index, seg_index)
         if t_stop is None:
             t_stop = self._segment_t_stop(block_index, seg_index)
 
         mask = self._get_temporal_mask(t_start, t_stop, tetrode_id)
-        
+
         # unwrap mask to match waveform dimension
         mask = np.repeat(mask, 4)
         mask = mask[:len(waveforms)]
@@ -433,7 +437,7 @@ class AxonaRawIO(BaseRawIO):
     # This is largely based on code by Geoff Barrett from the Hussaini lab:
     # https://github.com/GeoffBarrett/BinConverter
     # Adapted or modified by Steffen Buergers, Julia Sprenger
-    
+
     def _get_temporal_mask(self, t_start, t_stop, tetrode_id):
         # Convenience function for creating a temporal mask given
         # start time (t_start) and stop time (t_stop)
@@ -442,7 +446,7 @@ class AxonaRawIO(BaseRawIO):
         # spike times are repeated for each contact -> use only first contact
         raw_spikes = self._raw_spikes[tetrode_id]
         unit_spikes = raw_spikes['spiketimes'][::4]
-        
+
         # convert t_start and t_stop to sampling frequency
         # Note: this assumes no time offset!
         unit_params = self.file_parameters['unit']
@@ -450,7 +454,7 @@ class AxonaRawIO(BaseRawIO):
         lim1 = t_stop * self._to_hz(unit_params['timebase'])
 
         mask = (unit_spikes >= lim0) & (unit_spikes <= lim1)
-        
+
         return mask
 
     def get_header_parameters(self, file, file_type):

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -123,15 +123,16 @@ class AxonaRawIO(BaseRawIO):
         params['set']['file_header'] = set_dict
         params['set']['sampling_rate'] = int(set_dict['rawRate'])
 
+        signal_streams = self._get_signal_streams_header()
+        signal_channels = self._get_signal_chan_header()
+
         # SCAN BIN FILE
-        signal_streams = []
-        signal_channels = []
         if self.bin_file:
             bin_dict = self.file_parameters['bin']
             # add derived parameters from bin file
             bin_dict['num_channels'] = len(self.get_active_tetrode()) * 4
-            num_tot_packets = int(self.bin_file.stat().st_size
-                                  / bin_dict['bytes_packet'])
+            num_tot_packets = int(
+                self.bin_file.stat().st_size / bin_dict['bytes_packet'])
             bin_dict['num_total_packets'] = num_tot_packets
             bin_dict['num_total_samples'] = num_tot_packets * 3
 
@@ -140,9 +141,6 @@ class AxonaRawIO(BaseRawIO):
                 self.bin_file, dtype=self.file_parameters['bin']['data_type'],
                 mode='r', offset=self.file_parameters['bin']['header_size']
             )
-
-            signal_streams = self._get_signal_streams_header()
-            signal_channels = self._get_signal_chan_header()
 
         # SCAN TETRODE FILES
         # In this IO one tetrode corresponds to one unit

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -270,7 +270,7 @@ class AxonaRawIO(BaseRawIO):
             return self.file_parameters['bin']['num_total_samples']
         else:
             sr = self.file_parameters['set']['sampling_rate']
-            return int(self.file_parameters['unit']['duration'] * sr)
+            return int(float(self.file_parameters['unit']['duration']) * sr)
 
     def _get_signal_t_start(self, block_index, seg_index, stream_index):
         return 0.

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -294,6 +294,17 @@ class AxonaRawIO(BaseRawIO):
         sample 3: 32b (head) + 128*2 (all channels 1st and 2nd entry) + ...
         """
 
+        if self.bin_file is None:
+
+            # NOTE: Passing None or an empty array is not permitted in neo. Here,
+            # we create a fake continuous recording from the tetrode files, filling
+            # data in-between spikes with Gaussian noise. Ultimately we may want to
+            # move the axonaunitextractor.get_traces() code in here instead, going
+            # back and forth is a bit funny.
+            from spikeextractors.extractors.axonaunitrecordingextractor import AxonaUnitRecordingExtractor
+            ue = AxonaUnitRecordingExtractor(filename=self.set_file)
+            return ue.get_traces(return_scaled=False).transpose()
+
         bin_dict = self.file_parameters['bin']
 
         # Set default values

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -183,7 +183,7 @@ class AxonaRawIO(BaseRawIO):
                 wf_sampling_rate = spikemode_to_sr.get(int(sm), None)
                 if wf_sampling_rate is None:
                     wf_sampling_rate = self._to_hz(tdict['sample_rate'],
-                                                   dtype=float)
+                                               dtype=float)
 
                 spike_channels.append((unit_name, unit_id, wf_units, wf_gain,
                                        wf_offset, wf_left_sweep,

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -123,16 +123,14 @@ class AxonaRawIO(BaseRawIO):
         params['set']['file_header'] = set_dict
         params['set']['sampling_rate'] = int(set_dict['rawRate'])
 
-        signal_streams = self._get_signal_streams_header()
-        signal_channels = self._get_signal_chan_header()
-
-        # SCAN BIN FILE
+        signal_streams = []
+        signal_channels = []
         if self.bin_file:
             bin_dict = self.file_parameters['bin']
             # add derived parameters from bin file
             bin_dict['num_channels'] = len(self.get_active_tetrode()) * 4
-            num_tot_packets = int(
-                self.bin_file.stat().st_size / bin_dict['bytes_packet'])
+            num_tot_packets = int(self.bin_file.stat().st_size
+                                  / bin_dict['bytes_packet'])
             bin_dict['num_total_packets'] = num_tot_packets
             bin_dict['num_total_samples'] = num_tot_packets * 3
 
@@ -141,6 +139,9 @@ class AxonaRawIO(BaseRawIO):
                 self.bin_file, dtype=self.file_parameters['bin']['data_type'],
                 mode='r', offset=self.file_parameters['bin']['header_size']
             )
+
+            signal_streams = self._get_signal_streams_header()
+            signal_channels = self._get_signal_chan_header()
 
         # SCAN TETRODE FILES
         # In this IO one tetrode corresponds to one unit

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -402,7 +402,7 @@ class AxonaRawIO(BaseRawIO):
     def _get_tetrode_channel_table(self, channel_ids):
         '''Create auxiliary np.array with the following columns:
         Tetrode ID, Channel ID, Channel ID within tetrode
-        This is useful in `_get_mock_analogsignal_chunk()`
+        This is useful in `get_traces()`
 
         Parameters
         ----------

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -402,7 +402,7 @@ class AxonaRawIO(BaseRawIO):
     def _get_tetrode_channel_table(self, channel_ids):
         '''Create auxiliary np.array with the following columns:
         Tetrode ID, Channel ID, Channel ID within tetrode
-        This is useful in `get_traces()`
+        This is useful in `_get_mock_analogsignal_chunk()`
 
         Parameters
         ----------

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -294,19 +294,26 @@ class AxonaRawIO(BaseRawIO):
         sample 3: 32b (head) + 128*2 (all channels 1st and 2nd entry) + ...
         """
 
+        if self.bin_file is None:
+
+            # NOTE: Passing None or an empty array is not permitted in neo. Here,
+            # we create a fake continuous recording from the tetrode files, filling
+            # data in-between spikes with Gaussian noise. Ultimately we may want to
+            # move the axonaunitextractor.get_traces() code in here instead, going
+            # back and forth is a bit funny.
+            from spikeextractors.extractors.axonaunitrecordingextractor import AxonaUnitRecordingExtractor
+            ue = AxonaUnitRecordingExtractor(filename=self.set_file)
+            return ue.get_traces(return_scaled=False).transpose()
+
         bin_dict = self.file_parameters['bin']
 
         # Set default values
         if i_start is None:
             i_start = 0
         if i_stop is None:
-            i_stop = self.get_signal_size(block_index=block_index, seg_index=seg_index)
+            i_stop = bin_dict['num_total_samples']
         if channel_indexes is None:
-            channel_indexes = [i for i in range(self.header['signal_channels'].shape[0])]
-
-        if self.bin_file is None:
-            return self._get_mock_analogsignal_chunk(channel_ids=channel_indexes,
-                                                     start_frame=i_start, end_frame=i_stop)
+            channel_indexes = [i for i in range(bin_dict['num_channels'])]
 
         num_samples = (i_stop - i_start)
 
@@ -317,7 +324,7 @@ class AxonaRawIO(BaseRawIO):
 
         raw_samples = np.arange(num_packets_oi + 1, dtype=np.uint32)
         sample1 = raw_samples * (bin_dict['bytes_packet'] // 2) + \
-            bin_dict['bytes_head'] // 2 + offset
+                  bin_dict['bytes_head'] // 2 + offset
         sample2 = sample1 + 64
         sample3 = sample2 + 64
 
@@ -338,98 +345,6 @@ class AxonaRawIO(BaseRawIO):
             raw_signals[:, i] = self._raw_signals[sig_ids + chan_offset]
 
         return raw_signals
-
-    def _get_mock_analogsignal_chunk(self, channel_ids, start_frame, end_frame,
-                                     noise_std=0, return_scaled=False):
-        # Create mock continuous recording from tetrode file (.X) data
-        # by filling Gaussian noise into gaps between waveforms.
-
-        timebase_sr = int(self.file_parameters['unit']['timebase'].split(' ')[0])
-        samples_pre = int(self.file_parameters['set']['file_header']['pretrigSamps'])
-        samples_post = int(self.file_parameters['set']['file_header']['spikeLockout'])
-        sampling_rate = int(self.file_parameters['set']['sampling_rate'])
-
-        tcmap = self._get_tetrode_channel_table(channel_ids)
-
-        traces = noise_std * np.random.randn(len(channel_ids), end_frame - start_frame)
-        if return_scaled:
-            traces = traces.astype(np.float32)
-        else:
-            traces = traces.astype(np.int8)
-
-        # Loop through tetrodes and include requested channels in traces
-        itrc = 0
-        for tetrode_id in np.unique(tcmap[:, 0]):
-
-            channels_oi = tcmap[tcmap[:, 0] == tetrode_id, 2]
-
-            waveforms = self._get_spike_raw_waveforms(
-                block_index=0, seg_index=0,
-                unit_index=tetrode_id - 1,  # Tetrodes IDs are 1-indexed
-                t_start=start_frame / sampling_rate,
-                t_stop=end_frame / sampling_rate
-            )
-            waveforms = waveforms[:, channels_oi, :]
-            nch = len(channels_oi)
-
-            spike_train = self._get_spike_timestamps(
-                block_index=0, seg_index=0,
-                unit_index=tetrode_id - 1,
-                t_start=start_frame / sampling_rate,
-                t_stop=end_frame / sampling_rate
-            )
-
-            # Fill waveforms into traces timestamp by timestamp
-            for t, wf in zip(spike_train, waveforms):
-
-                t = int(t // (timebase_sr / sampling_rate))  # timestamps are sampled at higher frequency
-                t = t - start_frame
-                if (t - samples_pre < 0) and (t + samples_post > traces.shape[1]):
-                    traces[itrc:itrc + nch, :] = wf[:, samples_pre - t:traces.shape[1] - (t - samples_pre)]
-                elif t - samples_pre < 0:
-                    traces[itrc:itrc + nch, :t + samples_post] = wf[:, samples_pre - t:]
-                elif t + samples_post > traces.shape[1]:
-                    traces[itrc:itrc + nch, t - samples_pre:] = wf[:, :traces.shape[1] - (t - samples_pre)]
-                else:
-                    traces[itrc:itrc + nch, t - samples_pre:t + samples_post] = wf
-
-            itrc += nch
-
-        return traces.transpose()
-
-    def _get_tetrode_channel_table(self, channel_ids):
-        '''Create auxiliary np.array with the following columns:
-        Tetrode ID, Channel ID, Channel ID within tetrode
-        This is useful in `get_traces()`
-
-        Parameters
-        ----------
-        channel_ids : list
-            List of channel ids to include in table
-
-        Returns
-        -------
-        np.array
-            Rows = channels,
-            columns = TetrodeID, ChannelID, ChannelID within Tetrode
-        '''
-        active_tetrodes = self.get_active_tetrode()
-
-        tcmap = np.zeros((len(active_tetrodes) * 4, 3), dtype=int)
-        row_id = 0
-        for tetrode_id in [int(s[0].split(' ')[1]) for s in self.header['spike_channels']]:
-
-            all_channel_ids = self._get_channel_from_tetrode(tetrode_id)
-
-            for i in range(4):
-                tcmap[row_id, 0] = int(tetrode_id)
-                tcmap[row_id, 1] = int(all_channel_ids[i])
-                tcmap[row_id, 2] = int(i)
-                row_id += 1
-
-        del_idx = [False if i in channel_ids else True for i in tcmap[:, 1]]
-
-        return np.delete(tcmap, del_idx, axis=0)
 
     def _spike_count(self, block_index, seg_index, unit_index):
         tetrode_id = unit_index

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -183,7 +183,7 @@ class AxonaRawIO(BaseRawIO):
                 wf_sampling_rate = spikemode_to_sr.get(int(sm), None)
                 if wf_sampling_rate is None:
                     wf_sampling_rate = self._to_hz(tdict['sample_rate'],
-                                               dtype=float)
+                                                   dtype=float)
 
                 spike_channels.append((unit_name, unit_id, wf_units, wf_gain,
                                        wf_offset, wf_left_sweep,

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -270,8 +270,7 @@ class AxonaRawIO(BaseRawIO):
         if 'num_total_packets' in self.file_parameters['bin']:
             return self.file_parameters['bin']['num_total_samples']
         else:
-            sr = self.file_parameters['set']['sampling_rate']
-            return int(float(self.file_parameters['unit']['duration']) * sr)
+            return 0
 
     def _get_signal_t_start(self, block_index, seg_index, stream_index):
         return 0.

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -382,16 +382,14 @@ class AxonaRawIO(BaseRawIO):
             # Fill waveforms into traces timestamp by timestamp
             for t, wf in zip(spike_train, waveforms):
 
-                t = int(t // (timebase_sr / sampling_rate))  # timestamps are at higher frequency
+                t = int(t // (timebase_sr / sampling_rate))  # timestamps are sampled at higher frequency
                 t = t - start_frame
                 if (t - samples_pre < 0) and (t + samples_post > traces.shape[1]):
-                    traces[itrc:itrc + nch, :] = \
-                        wf[:, samples_pre - t:traces.shape[1] - (t - samples_pre)]
+                    traces[itrc:itrc + nch, :] = wf[:, samples_pre - t:traces.shape[1] - (t - samples_pre)]
                 elif t - samples_pre < 0:
                     traces[itrc:itrc + nch, :t + samples_post] = wf[:, samples_pre - t:]
                 elif t + samples_post > traces.shape[1]:
-                    traces[itrc:itrc + nch, t - samples_pre:] = \
-                        wf[:, :traces.shape[1] - (t - samples_pre)]
+                    traces[itrc:itrc + nch, t - samples_pre:] = wf[:, :traces.shape[1] - (t - samples_pre)]
                 else:
                     traces[itrc:itrc + nch, t - samples_pre:t + samples_post] = wf
 

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -294,17 +294,6 @@ class AxonaRawIO(BaseRawIO):
         sample 3: 32b (head) + 128*2 (all channels 1st and 2nd entry) + ...
         """
 
-        if self.bin_file is None:
-
-            # NOTE: Passing None or an empty array is not permitted in neo. Here,
-            # we create a fake continuous recording from the tetrode files, filling
-            # data in-between spikes with Gaussian noise. Ultimately we may want to
-            # move the axonaunitextractor.get_traces() code in here instead, going
-            # back and forth is a bit funny.
-            from spikeextractors.extractors.axonaunitrecordingextractor import AxonaUnitRecordingExtractor
-            ue = AxonaUnitRecordingExtractor(filename=self.set_file)
-            return ue.get_traces(return_scaled=False).transpose()
-
         bin_dict = self.file_parameters['bin']
 
         # Set default values


### PR DESCRIPTION
Depends on

- [x] https://github.com/JuliaSprenger/python-neo/pull/3

I am going through all the errors thrown when there is no bin file available. For instance, the `signal_streams` and `signal_channels` were only assigned when a bin file was given. 

The next issue was that the `_get_signal_size()` method used the `.bin` file to estimate the size of the signal. With these changes, we now use the sampling rate and the duration of the recording (both retrieved from the set file) to estimate the total number of samples if there is no .bin file. 

This is not really optimal, because the sampling frequency between .bin and UNIT data can of course be different. But we might take care of that in `AxonaUnitRecordingExtractor` in spikeextractors for now. Adding a parameter to say if you want the total number of samples for either .bin data or UNIT data might be another option, what do you think?